### PR TITLE
Ch 5 edits

### DIFF
--- a/05-GeomManipulations.Rmd
+++ b/05-GeomManipulations.Rmd
@@ -71,6 +71,8 @@ st_is_longlat(nc2)
 st_is_longlat(st_point(0:1))
 ```
 
+[comment]: FIXME should `st_is_longlat` reject st_point(0, 95)? It isn't just NA, it cannot be longlat.
+
 `st_is` is an easy way to check for the simple feature geometry type: 
 ```{r}
 st_is(st_point(0:1), "POINT")

--- a/05-GeomManipulations.Rmd
+++ b/05-GeomManipulations.Rmd
@@ -274,7 +274,7 @@ Binary functions that return a geometry include
 |`st_difference`|the geometries of the first after removing the overlap with the second geometry|`/`|
 |`st_sym_differenc`|the combinations of the geometries after removing where they overlap|`%/%`|
 
-When operating on two `sfg`, single geometries it is clear what
+When operating on two `sfg`, single geometries, it is clear what
 all these functions do: return a single geometry for this pair.
 When given two {\em sets} of geometries (`sfc` or `sf` objects),
 a new set of geometries is returned; for `st_intersection`


### PR DESCRIPTION
Small things, one comment on whether st_is_longlat should reject sfg coordinates that go outside feasible bounds, or continue to return NA. Since the projection belongs (?) to an sfc, an sfg might be answered FALSE if it could not be longlat? If not sensible, a clarifying comment might be helpful.