### PR TITLE
update link to dc figure script, apply-update

### DIFF
--- a/06-Cubes.Rmd
+++ b/06-Cubes.Rmd
@@ -112,7 +112,7 @@ text( 5,  8.5, "longitude", srt = 0, col = 'black')
 
 ```{r cube4d, fig.width=10, cache = TRUE, fig.cap="Four-dimensional raster data cube with dimensions x, y, bands and time", echo=!knitr::is_latex_output()}
 # (C) 2021, Jonathan Bahlmann, CC-BY-SA
-#  https://github.com/Open-EO/openeo.org/tree/datacube_doc/documentation/1.0/datacubes/.scripts
+# https://github.com/Open-EO/openeo.org/tree/master/documentation/1.0/datacubes/.scripts
 # based on work by Edzer Pebesma, 2019, here: https://gist.github.com/edzer/5f1b0faa3e93073784e01d5a4bb60eca
 
 # plotting runs via a dummy stars object with x, y dimensions (no bands)


### PR DESCRIPTION
On a second note @edzer, figures of `apply` processes have been [updated](https://openeo.org/documentation/1.0/datacubes.html#apply). Maybe one of these are better suited for the book now?
![dc_apply_ts](https://raw.githubusercontent.com/Open-EO/openeo.org/master/documentation/1.0/datacubes/dc_apply_ts.png)
for applying on neighbourhood of 3,
![dc_apply_dim_ts](https://raw.githubusercontent.com/Open-EO/openeo.org/master/documentation/1.0/datacubes/dc_apply_dim_ts.png)
for applying to whole dimension.