### PR TITLE
Typo in pandoc heading identifier

### DIFF
--- a/17-Areal.Rmd
+++ b/17-Areal.Rmd
@@ -96,7 +96,7 @@ all.equal(nb_q, nb_q_s2, check.attributes=FALSE)
 
 Note that `nb` objects record both symmetric neighbour relationships, because these objects admit asymmetric relationships as well, but these duplications are not needed for object construction.
 
-Most of the **spdep** functions for constructing neighbour objects take a `row.names=` argument, the value of which is stored as a `region.id` attribute. If not given, the values are taken from `row.names()` of the first argument. These can be used to check that the neighbours object is in the same order as data. If `nb` objects are subsetted, the indices change to continue to be within `1:length(subsetted_nb)`, but the `region.id` attribute values point back to the object from which it was constructed. This is used in out-of-sample prediction from spatial regression models discussed briefly in section \@ref(spatecon_pred).
+Most of the **spdep** functions for constructing neighbour objects take a `row.names=` argument, the value of which is stored as a `region.id` attribute. If not given, the values are taken from `row.names()` of the first argument. These can be used to check that the neighbours object is in the same order as data. If `nb` objects are subsetted, the indices change to continue to be within `1:length(subsetted_nb)`, but the `region.id` attribute values point back to the object from which it was constructed. This is used in out-of-sample prediction from spatial regression models discussed briefly in section \@ref(spatecon-pred).
 
 We can also check that this undirected graph is connected using the `n.comp.nb()` function; while some model estimation techniques do not support graphs that are not connected, it is helpful to be aware of possible problems [@FRENISTERRANTINO201825]:
 ```{r}

--- a/18-SpatialRegression.Rmd
+++ b/18-SpatialRegression.Rmd
@@ -556,7 +556,7 @@ sum_imp_94_SLXw <- summary(impacts(SLX_94w))
 rbind(Impacts = sum_imp_94_SLXw$mat[5,], SE = sum_imp_94_SLXw$semat[5,])
 ```
 
-## Predictions {#spatecon_pred}
+## Predictions {#spatecon-pred}
 
 In the Boston tracts data set, 17 observations of median house values, the response, are censored. We will use the `predict()` method for `"Sarlm"` objects to fill in these values; the method was re-written by Martin Gubri based on @goulardetal:17 [see also @Laurent2021]. The `pred.type=` argument specifies the prediction strategy among those presented in the article.
 


### PR DESCRIPTION
Dear all, I noticed that there is a malformed reference in [Section 14.2](https://keen-swartz-3146c4.netlify.app/area.html#contiguous-neighbours) and I think it may be linked to the fact that you cannot use underscores in ids (https://stackoverflow.com/questions/57469501/cross-referencing-bookdownhtml-document2-not-working). 

