### PR TITLE
add possible fix for args()

### DIFF
--- a/14-Areal.qmd
+++ b/14-Areal.qmd
@@ -44,6 +44,13 @@ We will be using election data from the 2015 Polish Presidential election in thi
 
 ```{r setup_sa0, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE, paged.print=FALSE)
+owidth <- getOption("width")
+xargs <- function(x) {
+    o <- capture.output(args(x))
+    oo <- gsub("  *", " ", paste(o[-length(o)], collapse=""))
+    ooo <- strwrap(oo, width=getOption("width"), indent=1, exdent=3)
+    cat(paste(ooo, collapse="\n"), "\n")
+}
 ```
 
 ```{r}
@@ -89,8 +96,11 @@ library(spdep) |> suppressPackageStartupMessages()
 
 The `poly2nb()` function in **spdep** takes the boundary points making up the polygon boundaries in the object passed as the `pl=` argument, typically an `"sf"` or `"sfc"` object with `"POLYGON"` or `"MULTIPOLYGON"` geometries. For each observation, the function checks whether at least one (`queen=TRUE`, default), or at least two (rook, `queen=FALSE`) points are within `snap=` distance units of each other. The distances are planar in the raw coordinate units, ignoring geographical projections. Once the required number of sufficiently close points is found, the search is stopped.
 
-```{r}
+```{r, echo=TRUE, eval=FALSE}
 args(poly2nb)
+```
+```{r, echo=FALSE, eval=TRUE}
+xargs(poly2nb)
 ```
 From **spdep** 1.1-7, the **sf** package GEOS interface is used within `poly2nb()` to find the candidate neighbours and populate `foundInBox` internally. In this case, the use of spatial indexing (STRtree queries) in GEOS through **sf** is the default:
 
@@ -407,14 +417,20 @@ Once neighbour objects are available, further choices need to made in specifying
 \index{weights!objects}
 \index{weights!listw}
 
-```{r}
+```{r, echo=TRUE, eval=FALSE}
 args(nb2listw)
+```
+```{r, echo=FALSE, eval=TRUE}
+xargs(nb2listw)
 ```
 We will be using the helper function `spweights.constants()` below to show some consequences of varying style choices. It returns constants for a `listw` object, $n$ is the number of observations, `n1` to `n3` are $n-1, \ldots$, `nn` is $n^2$ and $S_0$, $S_1$ and $S_2$ are constants, $S_0$ being the sum of the weights. There is a full discussion of the constants in Bivand and Wong [-@Bivand2018].
 
 \index[function]{spweights.constants}
-```{r}
+```{r, echo=TRUE, eval=FALSE}
 args(spweights.constants)
+```
+```{r, echo=FALSE, eval=TRUE}
+xargs(spweights.constants)
 ```
 The `"B"` binary style gives a weight of unity to each neighbour relationship, and typically up-weights units with no boundaries on the edge of the study area, so having a higher count of neighbours.
 

--- a/15-Measures.qmd
+++ b/15-Measures.qmd
@@ -4,6 +4,13 @@
 
 ```{r setup_sa1, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE, paged.print = FALSE)
+owidth <- getOption("width")
+xargs <- function(x) {
+    o <- capture.output(args(x))
+    oo <- gsub("  *", " ", paste(o[-length(o)], collapse=""))
+    ooo <- strwrap(oo, width=getOption("width"), indent=1, exdent=3)
+    cat(paste(ooo, collapse="\n"), "\n")
+}
 ```
 ```{r echo=FALSE}
 load("ch14.RData")
@@ -97,8 +104,11 @@ We will begin by examining join count statistics, where `joincount.test()` takes
 
 \index[function]{joincount.test}
 
-```{r}
+```{r, echo=TRUE, eval=FALSE}
 args(joincount.test)
+```
+```{r, echo=FALSE, eval=TRUE}
+xargs(joincount.test)
 ```
 The function takes an `alternative=` argument for hypothesis testing, a `sampling=` argument showing the basis for the construction of the variance of the measure, where the default `"nonfree"` choice corresponds to analytical permutation; the `spChk=` argument is retained for backward compatibility. For reference, the counts of factor levels for the type of municipality or Warsaw borough are:
 
@@ -129,8 +139,11 @@ Types |> joincount.multi(listw = lw_d183_idw_B)
 
 The implementation of Moran's $I$ in **spdep** in the `moran.test()` function has similar arguments to those of `joincount.test()`, but `sampling=` is replaced by `randomisation=` to indicate the underlying analytical approach used for calculating the variance of the measure. It is also possible to use ranks rather than numerical values [@cliff+ord:81, p. 46]. The `drop.EI2=` argument may be used to reproduce results where the final component of the variance term is omitted as found in some legacy software implementations.
 
-```{r}
+```{r, echo=TRUE, eval=FALSE}
 args(moran.test)
+```
+```{r, echo=FALSE, eval=TRUE}
+xargs(moran.test)
 ```
 
 \index[function]{moran.test}
@@ -224,8 +237,11 @@ tm_shape(pol_pres15) + tm_fill("hat_value")
 
 Bivand and Wong [-@Bivand2018] discuss issues impacting the use of local indicators, such as local Moran's $I_i$ and local Getis-Ord $G_i$. Some issues affect the calculation of the local indicators, others inference from their values. Because $n$ statistics may be being calculated from the same number of observations, there are multiple comparison problems that need to be addressed. @https://doi.org/10.1111/j.0016-7363.2006.00682.x  conclude, based on a typical dataset and a simulation exercise, that the false discovery rate (FDR) adjustment of probability values will certainly give a better picture of interesting clusters than no adjustment. Following this up, @https://doi.org/10.1111/gean.12164 explores the combination of FDR adjustments with the use of redefined "significance" cutoffs [@benjaminetal:18], for example $0.01$, $0.005$ and $0.001$ instead of $0.1$, $0.05$ and $0.01$; the use of the term *interesting* rather than *significant* is also preferred. This is discussed further in @bivand:22. As in the global case, mis-specification remains a source of confusion, and, further, interpreting local spatial autocorrelation in the presence of global spatial autocorrelation is challenging [@ord+getis:01; @tiefelsdorf:02; @bivandetal:09]. 
 
-```{r}
+```{r, echo=TRUE, eval=FALSE}
 args(localmoran)
+```
+```{r, echo=FALSE, eval=TRUE}
+xargs(localmoran)
 ```
 \index[function]{localmoran}
 


### PR DESCRIPTION
adds a wrapper function to capture output and use `strwrap()` to apply `getOption("width")`. Depends on picking up the width from somewhere conditioning on render format. Maybe to check add printout of current width?