### PR TITLE
Fix URLs

### DIFF
--- a/sp-raster.qmd
+++ b/sp-raster.qmd
@@ -13,7 +13,7 @@ existing R packages depending on these packages.  The answer is: yes.
 The plan is to retire **maptools**, **rgdal** and **rgeos** during
 2023. Retirement means that maintenance will halt, and that as a
 consequence the packages will be archived on CRAN. The source code
-repositories on R-Forge will remain as long as R-Forge does itsef.
+repositories on R-Forge will remain as long as R-Forge does itself.
 One reason for retirement is that their maintainer has retired,
 a more important reason that their role has been superseded by the newer packages.
 We hold it most unlikely that a new maintainer will take over the 
@@ -66,7 +66,7 @@ geometry types, cannot be converted into `sp` objects
 * attribute-geometry relationship attributes get lost when converting
   to **sp**
 * `sf` objects with more than one geometry list-column will, when
-converting to **sp**, loose their secondary list-column(s).
+converting to **sp**, lose their secondary list-column(s).
 
 
 ## Migration code and packages
@@ -74,7 +74,7 @@ converting to **sp**, loose their secondary list-column(s).
 
 The wiki page of the GitHub site for **sf**, found at
 
-    https://github.com/r-spatial/sf/wiki/Migrating
+    <https://github.com/r-spatial/sf/wiki/Migrating>
 
 contains a list of methods and functions in **rgeos**, **rgdal** and
 **sp** and the corresponding **sf** method or function. This may help
@@ -92,7 +92,7 @@ An effort by us is underway to convert all code of our earlier book
 "Applied Spatial Data Analysis with R" (with Virgilio Gomez-Rubio,
 @asdar) to run entirely without **rgdal**, **rgeos** and **maptools** and
 where possible without **sp**. The scripts are found at
-https://github.com/rsbivand/sf_asdar2ed .
+<https://github.com/rsbivand/sf_asdar2ed>.
 
 ## Package raster and terra
 \index{raster}
@@ -118,13 +118,13 @@ can be converted to `stars` objects using `st_as_stars()`. Package
 from package **terra**. 
 
 The online book "Spatial Data Science with R", written by
-Robert Hijmans and found at https://rspatial.org/terra details
+Robert Hijmans and found at <https://rspatial.org/terra> details
 the **terra** approach to spatial data analysis. Package **sf**
 and **stars** and several other r-spatial packages discussed in
 this book reside on the `r-spatial` GitHub organisation (note the
 hyphen between `r` and `spatial`, which is absent on Hijmans'
 organisation), which has a blog site, with links to this book,
-found at [https://r-spatial.org/book](https://r-spatial.org/book/).
+found at <https://r-spatial.org/book>.
 
 Packages **sf** and **stars** on one hand and **terra** on the other
 have many goals in common, but try to reach them in slightly


### PR DESCRIPTION
I haven't used Quarto yet, but it looks like the links have to be written in `<>`. In RMarkdown it works automatically without `<>`.