### PR TITLE
Remove doi.org prefix from DOIs

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -121,23 +121,23 @@ doi = {10.1080/13658816.2016.1151520}
   year={2008},
   publisher={Springer}
 }
-@article{rouault_even_warmerdam_frank_schwehr_kurt_kiselev_andrey_butler_howard_łoskot_mateusz_2022, 
-title={GDAL}, 
-DOI={10.5281/zenodo.5884352}, 
-abstractNote={<p>GDAL is a translator library for raster and vector geospatial data formats that is released under an X/MIT style Open Source License by the Open Source Geospatial Foundation. As a library, it presents a single raster abstract data model and single vector abstract data model to the calling application for all supported formats. It also comes with a variety of useful command line utilities for data translation and processing.</p>}, 
-publisher={Zenodo}, 
-author={Rouault, Even and Warmerdam, Frank and Schwehr, Kurt and Kiselev, Andrey and Butler, Howard and Łoskot, Mateusz}, 
-year={2022}, 
-month={Jan} 
+@article{rouault_even_warmerdam_frank_schwehr_kurt_kiselev_andrey_butler_howard_łoskot_mateusz_2022,
+title={GDAL},
+DOI={10.5281/zenodo.5884352},
+abstractNote={<p>GDAL is a translator library for raster and vector geospatial data formats that is released under an X/MIT style Open Source License by the Open Source Geospatial Foundation. As a library, it presents a single raster abstract data model and single vector abstract data model to the calling application for all supported formats. It also comes with a variety of useful command line utilities for data translation and processing.</p>},
+publisher={Zenodo},
+author={Rouault, Even and Warmerdam, Frank and Schwehr, Kurt and Kiselev, Andrey and Butler, Howard and Łoskot, Mateusz},
+year={2022},
+month={Jan}
 }
-@article{evenden_gerald_i._rouault_even_warmerdam_frank_evers_kristian_knudsen_thomas_butler_howard_2022, 
-title={PROJ}, 
-DOI={10.5281/zenodo.5884395}, 
-abstractNote={<p>PROJ is a generic coordinate transformation software that transforms geospatial coordinates from one coordinate reference system (CRS) to another. This includes cartographic projections as well as geodetic transformations.</p>}, 
-publisher={Zenodo}, 
-author={Evenden, Gerald I. and Rouault, Even and Warmerdam, Frank and Evers, Kristian and Knudsen, Thomas and Butler, Howard}, 
-year={2022}, 
-month={Jan} 
+@article{evenden_gerald_i._rouault_even_warmerdam_frank_evers_kristian_knudsen_thomas_butler_howard_2022,
+title={PROJ},
+DOI={10.5281/zenodo.5884395},
+abstractNote={<p>PROJ is a generic coordinate transformation software that transforms geospatial coordinates from one coordinate reference system (CRS) to another. This includes cartographic projections as well as geodetic transformations.</p>},
+publisher={Zenodo},
+author={Evenden, Gerald I. and Rouault, Even and Warmerdam, Frank and Evers, Kristian and Knudsen, Thomas and Butler, Howard},
+year={2022},
+month={Jan}
 }
 @article{tidy,
    author = {Hadley  Wickham},
@@ -153,7 +153,7 @@ title = {{GDAL} - Geospatial Data Abstraction Library, Version 2.1.1},
 author = {{GDAL Development Team}},
 organization = {Open Source Geospatial Foundation},
 year = {2017},
-url = {http://www.gdal.org}, 
+url = {http://www.gdal.org},
 }
 @Manual{GEOS,
 title = {{GEOS} - Geometry Engine, Open Source},
@@ -529,7 +529,7 @@ author = "Van Huyen Do and Christine Thomas-Agnan and Anne Vanhems"
 @article{do,
   author = {Van Huyen Do and Christine Thomas-Agnan and Anne Vanhems},
   title={Spatial reallocation of areal data: a review},
-  journal={Rev. Econ. Rég. Urbaine}, 
+  journal={Rev. Econ. Rég. Urbaine},
   volume={1/2},
   year=2015,
   pages={27-58},
@@ -657,7 +657,7 @@ doi = {10.1080/13658816.2014.1002499}
 }
 @article{tiefelsdorf:02,
    author = {Tiefelsdorf, M.},
-   title = {The Saddlepoint approximation of {Moran}'s {I} 
+   title = {The Saddlepoint approximation of {Moran}'s {I}
      and local {Moran}'s ${I}_i$ reference distributions and their numerical
      evaluation},
    journal = {Geographical Analysis},
@@ -951,13 +951,13 @@ year  = {2007},
 publisher = {Taylor \& Francis},
 doi = {10.1080/13658810601034267},
 
-URL = { 
+URL = {
         https://doi.org/10.1080/13658810601034267
-    
+
 },
-eprint = { 
+eprint = {
         https://doi.org/10.1080/13658810601034267
-    
+
 }
 
 }
@@ -982,7 +982,7 @@ volume = "52",
 pages = "70 - 80",
 year = "2015",
 issn = "0198-9715",
-doi = "https://doi.org/10.1016/j.compenvurbsys.2015.03.005",
+doi = "10.1016/j.compenvurbsys.2015.03.005",
 url = "http://www.sciencedirect.com/science/article/pii/S019897151500040X",
 author = "Bing She and Xinyan Zhu and Xinyue Ye and Wei Guo and Kehua Su and Jay Lee"
 }
@@ -1024,7 +1024,7 @@ address = {New York}
 @book{upton+fingleton:85,
 author = {Upton, G. and Fingleton, B.},
 year = {1985},
-title = {Spatial data analysis by example: point pattern and qualitative data}, 
+title = {Spatial data analysis by example: point pattern and qualitative data},
 publisher =	{Wiley},
 address =	{New York}
 }
@@ -1056,8 +1056,8 @@ note={pp. 18}
 }
 
 @Article{alam-ronnegard-shen:2015,
-  author       = {Moudud Alam and Lars R\"{o}nneg{\aa}rd and Xia Shen}, 
-  title        = {Fitting Conditional and Simultaneous Autoregressive Spatial Models in hglm}, 
+  author       = {Moudud Alam and Lars R\"{o}nneg{\aa}rd and Xia Shen},
+  title        = {Fitting Conditional and Simultaneous Autoregressive Spatial Models in hglm},
   journal      = {The {R} Journal},
   year         = 2015,
   volume       = 7,
@@ -1265,13 +1265,13 @@ pages = {282--284}
 }
 
 @article{CliffOrd:72,
-author={Cliff, A. and Ord, J.K.}, 
-title={Testing for Spatial Autocorrelation among Regression Residuals}, 
+author={Cliff, A. and Ord, J.K.},
+title={Testing for Spatial Autocorrelation among Regression Residuals},
 journal={Geographical Analysis},
 volume={4},
 number={},
 year={1972},
-pages={267-284} 
+pages={267-284}
 }
 @article{besag:74,
      title = {Spatial Interaction and the Statistical Analysis of Lattice Systems},
@@ -1302,14 +1302,14 @@ Pages = {1--19},
 }
 
 @inproceedings{hepple:76,
-author={Hepple, Leslie W.}, 
-title={A maximum likelihood model for econometric estimation with spatial series}, 
+author={Hepple, Leslie W.},
+title={A maximum likelihood model for econometric estimation with spatial series},
 editor={I. Masser},
 booktitle={Theory and Practice in Regional Science},
 series={London Papers in Regional Science},
 publisher={Pion},
 address={London},
-pages={90--104}, 
+pages={90--104},
 year={1976}
 }
 
@@ -1368,7 +1368,7 @@ volume = "120",
 pages = "98 - 110",
 year = "2018",
 issn = "0167-9473",
-doi = "https://doi.org/10.1016/j.csda.2017.11.004",
+doi = "10.1016/j.csda.2017.11.004",
 url = "http://www.sciencedirect.com/science/article/pii/S0167947317302396",
 author = "Thomas Suesse",
 keywords = "SAR model, EM algorithm, Marginal likelihood, Missing data, Maximum likelihood",
@@ -1522,7 +1522,7 @@ volume = "64",
 pages = "30 - 45",
 year = "2017",
 issn = "0166-0462",
-doi = "https://doi.org/10.1016/j.regsciurbeco.2017.02.002",
+doi = "10.1016/j.regsciurbeco.2017.02.002",
 url = "http://www.sciencedirect.com/science/article/pii/S0166046217300546",
 author = "Davide Martinetti and Ghislain Geniaux",
 keywords = "Spatial probit, Multivariate normal probabilities, Spatial auto-regressive model, Spatial error model, Spatial discrete choice models",
@@ -1548,7 +1548,7 @@ pages = "119 - 122",
 year = "2015",
 note = "Spatial Statistics conference 2015",
 issn = "1878-0296",
-doi = "https://doi.org/10.1016/j.proenv.2015.05.013",
+doi = "10.1016/j.proenv.2015.05.013",
 url = "http://www.sciencedirect.com/science/article/pii/S1878029615001802",
 author = "Daniel Griffith and Roger Bivand and Yongwan Chun",
 keywords = "Extreme eigenvalues, Spatial regression, Rayleigh quotient",
@@ -1563,7 +1563,7 @@ pages = "116 - 118",
 year = "2015",
 note = "Spatial Statistics conference 2015",
 issn = "1878-0296",
-doi = "https://doi.org/10.1016/j.proenv.2015.07.119",
+doi = "10.1016/j.proenv.2015.07.119",
 url = "http://www.sciencedirect.com/science/article/pii/S187802961500331X",
 author = "Virgilio Gómez-Rubio and Roger Bivand and Håvard Rue",
 keywords = "Integrated Nested Laplace Approximation, Spatial econometrics",
@@ -1590,7 +1590,7 @@ volume = {26},
 pages = {25-34},
 year = {2018},
 issn = {1877-5845},
-doi = {https://doi.org/10.1016/j.sste.2018.04.002},
+doi = {10.1016/j.sste.2018.04.002},
 author = {Anna Freni-Sterrantino and Massimo Ventrucci and Håvard Rue}
 }
 @article{https://doi.org/10.1002/wics.1212,
@@ -1600,7 +1600,7 @@ journal = {WIREs Computational Statistics},
 volume = {4},
 number = {4},
 pages = {394-398},
-doi = {https://doi.org/10.1002/wics.1212},
+doi = {10.1002/wics.1212},
 year = {2012}
 }
 
@@ -1670,7 +1670,7 @@ volume = "20",
 pages = "125 - 147",
 year = "2017",
 issn = "2211-6753",
-doi = "https://doi.org/10.1016/j.spasta.2017.02.006",
+doi = "10.1016/j.spasta.2017.02.006",
 url = "http://www.sciencedirect.com/science/article/pii/S2211675317300696",
 author = "Dietrich Stoyan and Francisco J. Rodríguez-Cortés and Jorge Mateu and Wilfried Gille"
 }
@@ -1728,7 +1728,7 @@ volume = "4",
 pages = "33 - 49",
 year = "2013",
 issn = "1877-5845",
-doi = "https://doi.org/10.1016/j.sste.2012.12.001",
+doi = "10.1016/j.sste.2012.12.001",
 url = "http://www.sciencedirect.com/science/article/pii/S1877584512000846",
 author = "Marta Blangiardo and Michela Cameletti and Gianluca Baio and Håvard Rue"
 }
@@ -1763,7 +1763,7 @@ author = "Marta Blangiardo and Michela Cameletti and Gianluca Baio and Håvard R
 
 @inproceedings{schlather,
   author = {Martin Schlather},
-  year = {2011}, 
+  year = {2011},
   title = {Construction of covariance functions and unconditional simulation of random fields},
   booktitle = { Porcu, E., Montero, J.M. and Schlather, M., Space-Time Processes and Challenges Related to Environmental Problems},
   publisher = {New York: Springer}
@@ -1817,20 +1817,20 @@ author = "Marta Blangiardo and Michela Cameletti and Gianluca Baio and Håvard R
 }
 
 @article{toblerpyc,
-  author = {Tobler, W.R.}, 
+  author = {Tobler, W.R.},
   year = {1979},
   title = { Smooth pycnophylactic interpolation for geographical regions},
   journal = {Journal of the American Statistical Association},
   volume = {74},
-  issue = {367}, 
+  issue = {367},
   pages = {519-530}
 }
 @article{martin89,
-  author = {Martin, D.}, 
-  year = {1989}, 
+  author = {Martin, D.},
+  year = {1989},
   title = {Mapping population data from zone centroid locations},
   journal = {Transactions of the Institute of British Geographers, New Series},
-  volume = {14}, 
+  volume = {14},
   issue = {1},
   pages = {90-97}
 }
@@ -1840,7 +1840,7 @@ author = "Marta Blangiardo and Michela Cameletti and Gianluca Baio and Håvard R
    year = {2004},
    title = {A Geostatistical Framework for Areal-to-Point Spatial Interpolation},
    journal = {Geographical Analysis},
-   volume = {36}, 
+   volume = {36},
    issue = {3},
    pages = {259-289}
 }
@@ -1963,7 +1963,7 @@ url={https://www.fig.net/resources/proceedings/fig_proceedings/fig2017/papers/is
   number = {2},
   pages = {686-703},
   keywords = {design-based approach, design independence, effective sample size, model-assisted approach, model-based approach},
-  doi = {https://doi.org/10.1111/ejss.12988},
+  doi = {10.1111/ejss.12988},
   url = {https://onlinelibrary.wiley.com/doi/abs/10.1111/ejss.12988},
   eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1111/ejss.12988},
   year = {2021}
@@ -1988,7 +1988,7 @@ volume = {72},
 number = {2},
 pages = {686-703},
 keywords = {design-based approach, design independence, effective sample size, model-assisted approach, model-based approach},
-doi = {https://doi.org/10.1111/ejss.12988},
+doi = {10.1111/ejss.12988},
 url = {https://onlinelibrary.wiley.com/doi/abs/10.1111/ejss.12988},
 eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1111/ejss.12988},
 year = {2021}
@@ -2009,7 +2009,7 @@ author = { Hanna Meyer and Edzer Pebesma},
 title = { Machine learning-based global maps of ecological variables and the challenge of assessing them },
 journal = { Nature Communincations},
 volume = { 13 },
-issue = { 2208 }, 
+issue = { 2208 },
 year = {2022},
 url = { https://doi.org/10.1038/s41467-022-29838-9 }
 }
@@ -2022,7 +2022,7 @@ volume = {146},
 number = {730},
 pages = {1999-2049},
 keywords = {climate reanalysis, Copernicus Climate Change Service, data assimilation, ERA5, historical observations},
-doi = {https://doi.org/10.1002/qj.3803},
+doi = {10.1002/qj.3803},
 url = {https://rmets.onlinelibrary.wiley.com/doi/abs/10.1002/qj.3803},
 eprint = {https://rmets.onlinelibrary.wiley.com/doi/pdf/10.1002/qj.3803},
 year = {2020}
@@ -2156,7 +2156,7 @@ journal = {Ecology},
 volume = {95},
 number = {9},
 pages = {2434-2442},
-doi = {https://doi.org/10.1890/13-1997.1},
+doi = {10.1890/13-1997.1},
 year = {2014}
 }
 
@@ -2183,7 +2183,7 @@ journal = "Ecological Modelling",
 volume = "406",
 pages = "109 - 120",
 year = "2019",
-doi = "https://doi.org/10.1016/j.ecolmodel.2019.06.002",
+doi = "10.1016/j.ecolmodel.2019.06.002",
 author = "Patrick Schratz and Jannes Muenchow and Eugenia Iturritxa and Jakob Richter and Alexander Brenning"
 }
 @Article{math9111276,
@@ -2200,12 +2200,12 @@ ABSTRACT = {The software for spatial econometrics available in the {R} system fo
 DOI = {10.3390/math9111276}
 }
 @article{DiggleTawnMoyeed:98,
-  author = {P. J. Diggle and J. A. Tawn and R. A. Moyeed}, 
+  author = {P. J. Diggle and J. A. Tawn and R. A. Moyeed},
   title = {Model-based geostatistics},
   year = {1998},
   journal = {Applied Statistics},
   volumne = {47},
-  issue = {3}, 
+  issue = {3},
   pages = {299-350}
 }
 @book{Diggle:2007,
@@ -2213,7 +2213,7 @@ DOI = {10.3390/math9111276}
    author = { Diggle, P. J. and {Ribeiro Jr.}, P. J.},
    publisher = { Springer },
    address = {New York},
-   year = {	2007 } 
+   year = {	2007 }
 }
 @manual{appelblog,
   author = {Marius Appel and Edzer Pebesma and Matthias Mohr},
@@ -2265,7 +2265,7 @@ URL = {https://doi.org/10.1214/aos/1013699998}
   number = {n/a},
   pages = {},
   year="2021",
-  doi = {https://doi.org/10.1111/gean.12304}
+  doi = {10.1111/gean.12304}
 }
 @article{https://doi.org/10.1111/j.0016-7363.2006.00682.x,
 author = {Caldas de Castro, Marcia and Singer, Burton H.},
@@ -2467,7 +2467,7 @@ volume = {89},
 number = {1},
 pages = {248-267},
 keywords = {biologging, movement ecology, r project for statistical computing, spatial, tracking data},
-doi = {https://doi.org/10.1111/1365-2656.13116},
+doi = {10.1111/1365-2656.13116},
 year = {2020}
 }
 
@@ -2490,7 +2490,7 @@ number = {9223},
 pages = {64-68},
 year = {2000},
 issn = {0140-6736},
-doi = {https://doi.org/10.1016/S0140-6736(00)02442-9},
+doi = {10.1016/S0140-6736(00)02442-9},
 author = {Howard Brody and Michael Russell Rip and Peter Vinten-Johansen and Nigel Paneth and Stephen Rachman}
 }
 
@@ -2509,10 +2509,10 @@ author = {Howard Brody and Michael Russell Rip and Peter Vinten-Johansen and Nig
   author = { Raim, A.M. and Holan, S.H. and Bradley, J.R. and Wikle, C.K. },
   title = { Spatio-temporal change of support modeling with R. },
   journal = { Computational Statistics },
-  volume = { 36 }, 
+  volume = { 36 },
   pages = { 749--780},
   year = { 2021 },
-  doi = { https://doi.org/10.1007/s00180-020-01029-4 }
+  doi = { 10.1007/s00180-020-01029-4 }
 }
 
 @Manual{ctvspatial,


### PR DESCRIPTION
Hi all! This PR removes the `https://doi.org` prefix from DOIs which, when included, cause Quarto to render references incorrectly:

![image](https://user-images.githubusercontent.com/38229299/203554975-4c8d504f-0a8c-40e0-8016-66bb1db60802.png)

Thanks!