### PR TITLE
Suppress "figure"

### DIFF
--- a/06-Cubes.qmd
+++ b/06-Cubes.qmd
@@ -427,7 +427,7 @@ $$x = o_x + (i-1) d_x$$
 with $o_x$ the origin, and $d_x$ the grid spacing for this dimension.
 
 For more general cases like those in Figures
--@fig-rastertypes01 b-c, the relation between $x$ and $y$
+[-@fig-rastertypes01] b-c, the relation between $x$ and $y$
 and array indexes $i$ and $j$ is
 
 $$x = o_x + (i-1) d_x + (j-1) a_1$$


### PR DESCRIPTION
I'm just in a browser,  so double check me please. 

It currently renders as "those in Figures -Figure 1.6 b-c".

https://quarto.org/docs/authoring/cross-references.html#references

those in Figures -[Figure 1.6](https://r-spatial.org/book/01-hello.html#fig-rastertypes01) b-c